### PR TITLE
fix: Broken `done` and `delete` subcommands

### DIFF
--- a/src/TodoApp/Request.hs
+++ b/src/TodoApp/Request.hs
@@ -70,7 +70,7 @@ complete :: Int -> URI -> IO ()
 complete id host = do
   let payload =
         object ["done" .= ("true" :: String)]
-  q <- QueryParam <$> mkQueryKey "id" <*> mkQueryValue (pack $ show id)
+  q <- QueryParam <$> mkQueryKey "id" <*> mkQueryValue ("eq." <> pack (show id))
   path <- traverse mkPathPiece ["todos"]
   void $ request (R.ReqBodyJson payload) R.PATCH path [q] host
 
@@ -107,7 +107,7 @@ add task host = do
 delete :: Int -> URI -> IO ()
 delete id host = do
   path <- traverse mkPathPiece ["todos"]
-  q <- QueryParam <$> mkQueryKey "id" <*> mkQueryValue (pack $ show id)
+  q <- QueryParam <$> mkQueryKey "id" <*> mkQueryValue ("eq." <> pack (show id))
   void $ request R.NoReqBody R.DELETE path [q] host
 
 -- | Remove all the TODO items from the table


### PR DESCRIPTION
The HTTP request for `done` and `delete` failed with:

```sh
"{\"code\":\"PGRST104\",\"details\":\"Failed to parse [(\\\"id\\\",\\\"1\\\")]\",\"hint\":null,\"message\":\"Unexpected param or filter missing operator\"}"))
```

broken since https://github.com/juspay/todo-app/pull/14

Should be caught in CI after https://github.com/juspay/todo-app/issues/18