### PR TITLE
Use Unix socket to connect to `postgrest` and `postgres` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Learn with [our blog post series](https://nixos.asia/en/nixify-haskell):
 ## Prerequisite
 
 - [Install Nix](https://nixos.asia/en/install)
-- Stop any global postgres server running on port 5432.
 - Run application services
   - Run `nix run .#postgres` to start a postgres server with data dir in `./data/db`.
     - Run (once) `nix run .#createdb` to create DB user, load the dump and create the DB configuration for PostgREST.

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           ./nix/services/postgrest.nix
           ./nix/scripts.nix
           ./nix/todo-app.nix
+          ./nix/devshell.nix
         ];
       };
     };

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,9 @@
+{ pkgs, config, ... }:
+{
+  devShells.default = pkgs.mkShell {
+    inputsFrom = [
+      config.haskellProjects.default.outputs.devShell
+    ];
+    PGRST_SERVER_UNIX_SOCKET = config.services.postgrest.config.server-unix-socket;
+  };
+}

--- a/nix/services/postgres.nix
+++ b/nix/services/postgres.nix
@@ -27,7 +27,9 @@
                 # Initialize a database with data stored in current project dir
                 [ ! -d "./data/db" ] && initdb --no-locale -D ./data/db
 
-                postgres -D ./data/db -k "$PWD"/data
+                # Start postgres using Unix socket and disable listening on TCP port.
+                # Listening on TCP port is disabled by setting `listen_addresses` to empty string.
+                postgres -D ./data/db -k "$PWD"/data -c listen_addresses=""
               '';
           };
         in

--- a/nix/services/postgrest.nix
+++ b/nix/services/postgrest.nix
@@ -5,10 +5,14 @@
       enable = lib.mkEnableOption "postgrest";
       config = lib.mkOption {
         type = lib.types.attrsOf lib.types.str;
+        # TODO: use https://github.com/srid/flake-root for `db-uri` and `server-unix-socket`
         default = {
-          db-uri = "postgres://authenticator:mysecretpassword@localhost:5432/$(whoami)";
+          # Note: socket path in connection uri cannot contain `/`, so we need to URL-encode it.
+          # see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-KEYWORD-VALUE
+          db-uri = "postgres://\${PWD//\//%2F}%2Fdata/$(whoami)";
           db-schemas = "api";
           db-anon-role = "todo_user";
+          server-unix-socket = "./data/pgrst.sock";
         };
       };
     };
@@ -26,10 +30,12 @@
                 PGRST_DB_URI="${config.services.postgrest.config.db-uri}";
                 PGRST_DB_SCHEMAS="${config.services.postgrest.config.db-schemas}";
                 PGRST_DB_ANON_ROLE="${config.services.postgrest.config.db-anon-role}";
+                PGRST_SERVER_UNIX_SOCKET="${config.services.postgrest.config.server-unix-socket}";
                 # Have to export explicitly: https://www.shellcheck.net/wiki/SC2155
                 export PGRST_DB_URI;
                 export PGRST_DB_SCHEMAS;
                 export PGRST_DB_ANON_ROLE;
+                export PGRST_SERVER_UNIX_SOCKET;
                 postgrest
               '';
           };

--- a/nix/todo-app.nix
+++ b/nix/todo-app.nix
@@ -6,6 +6,7 @@
     #
     # For customization, see
     # https://github.com/srid/haskell-flake
+    autoWire = [ "packages" ];
   };
   packages = {
     default = self'.packages.todo-app;

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -39,22 +39,22 @@ runApp :: TR.Connection -> Opts -> IO ()
 runApp conn opts = do
   case optCommand opts of
     Add task -> do
-      TR.runRequest (TR.Add task) conn
+      TR.runRequest conn (TR.Add task)
       putStrLn "Task added!"
     Delete id -> do
-      TR.runRequest (TR.Delete id) conn
+      TR.runRequest conn (TR.Delete id)
       putStrLn "Task deleted!"
     Done id -> do
-      TR.runRequest (TR.Complete id) conn
+      TR.runRequest conn (TR.Complete id)
       putStrLn "Task completed!"
     View -> do
-      todo <- TR.runRequest TR.View conn
+      todo <- TR.runRequest conn TR.View
       mapM_ printTask todo
     ViewAll -> do
-      todo <- TR.runRequest TR.ViewAll conn
+      todo <- TR.runRequest conn TR.ViewAll
       mapM_ printTask todo
     Reset -> do
-      TR.runRequest TR.Reset conn
+      TR.runRequest conn TR.Reset
       putStrLn "Tasks cleared!"
   where
     printTask :: TR.Task -> IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -25,14 +25,15 @@ data Command
 
 main :: IO ()
 main = do
-  -- URI of the postgrest service
-  uri <- mkURI . T.pack . fromMaybe "http://localhost:3000" =<< lookupEnv "TODO_URI"
-  -- Connection type
-  connType <- maybe TR.TCP TR.UnixSocket <$> lookupEnv "PGRST_SERVER_UNIX_SOCKET"
+  -- Connection to the postgrest service
+  conn <- maybe
+    (TR.TCP <$> (mkURI . T.pack . fromMaybe "http://localhost:3000" =<< lookupEnv "TODO_URI"))
+    (pure . TR.UnixSocket)
+    =<< lookupEnv "PGRST_SERVER_UNIX_SOCKET"
   -- CLI options
   opts <- execParser optsParser
   -- Run the app
-  runApp (TR.Connection uri connType) opts
+  runApp conn opts
 
 runApp :: TR.Connection -> Opts -> IO ()
 runApp conn opts = do

--- a/src/TodoApp/Request.hs
+++ b/src/TodoApp/Request.hs
@@ -69,10 +69,10 @@ createUnixSocketManager socketPath = HC.newManager $ HC.defaultManagerSettings
 
 runRequest ::
   (MonadIO m, m ~ IO) =>
-  Request a ->
   Connection ->
+  Request a ->
   m a
-runRequest req conn = case req of
+runRequest conn = \case
   Complete id -> complete id conn
   ViewAll -> viewAll conn
   View -> view conn

--- a/src/TodoApp/Request.hs
+++ b/src/TodoApp/Request.hs
@@ -177,4 +177,3 @@ request body method paths qs conn = do
     if responseCode >= 200 && responseCode < 300
       then return $ R.responseBody r
       else error "Request failed"
-

--- a/todo-app.cabal
+++ b/todo-app.cabal
@@ -41,6 +41,7 @@ executable todo-app
     , http-client
     , lens
     , modern-uri
+    , network
     , optparse-applicative
     , req
     , text


### PR DESCRIPTION
resolves #15 

See demo of external services communicating using Unix socket during local development:

```sh
todo-app on  unix-socket [$] via λ 9.2.7 via ❄️  impure (nix-shell-env) took 7s
❯ lsof -i:5432

todo-app on  unix-socket [$] via λ 9.2.7 via ❄️  impure (nix-shell-env)
❯ lsof -i:3000

todo-app on  unix-socket [$] via λ 9.2.7 via ❄️  impure (nix-shell-env)
❯ cabal run todo-app -- view
Up to date
  [1]  finish tutorial 0

  [2]  pat self on back
```