### PR TITLE
Replace `TODO_URI` with `PGRST_SERVER_HOST` and `PGRST_SERVER_PORT`

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -85,7 +85,9 @@ getConnection = do
     Just path -> pure $ TR.UnixSocket path
     Nothing -> do
       todoUri <- lookupEnv "TODO_URI"
-      let defaultUri = "http://localhost:3000"
+      postgrestHost <- lookupEnv "PGRST_SERVER_HOST"
+      postgrestPort <- lookupEnv "PGRST_SERVER_PORT"
+      let defaultUri = "http://" <> fromMaybe "localhost" postgrestHost <> ":" <> fromMaybe "3000" postgrestPort
       let uri = fromMaybe defaultUri todoUri
       TR.TCP <$> mkURI (T.pack uri)
 


### PR DESCRIPTION
This is to not invent new ENVs and reuse the upstream ENVs. You can find the upstream ENVs in
https://docs.postgrest.org/en/stable/references/configuration.html#server-host